### PR TITLE
feat: Allow configuring build type for Android app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,63 +1,100 @@
-# Build Android App GitHub Action
+# KMP Build Android App Action
 
 ## Overview
 
-This GitHub Action is designed to build an Android application in debug mode using Gradle. It provides a streamlined process for compiling the Android project, with built-in caching to improve build performance.
-
-## Features
-
-- Sets up Java 17 development environment using Zulu OpenJDK
-- Configures Gradle build system
-- Implements caching to speed up subsequent builds
-- Builds specified Android module in debug configuration
-- Uploads generated APK as a workflow artifact
+This GitHub Action simplifies the process of building Android applications with support for multiple flavors (Demo and Prod) across different build types (Debug and Release).
 
 ## Inputs
 
 ### `android_package_name`
-- **Description**: Name of the Android project module to build
-- **Required**: Yes
-- **Type**: String
+- **Description**: Name of the Android project module
+- **Required**: `true`
+- **Type**: `string`
+- **Example**: `'app'`
 
-## Usage Example
+### `build_type`
+- **Description**: Type of build to perform
+- **Required**: `false`
+- **Default**: `'Debug'`
+- **Accepted Values**: `'Debug'`, `'Release'`
 
+## Outputs
+
+### `demo_apk`
+- **Description**: Full path to the generated Demo APK
+- **Type**: `string`
+- **Example**: `./app/build/outputs/apk/demo/debug/app-demo-debug.apk`
+
+### `prod_apk`
+- **Description**: Full path to the generated Prod APK
+- **Type**: `string`
+- **Example**: `./app/build/outputs/apk/prod/debug/app-prod-debug.apk`
+
+### Artifact Name
+- **Description**: Name of the generated artifact
+- **Type**: `string`
+- **Name**: `android-app`
+
+## Features
+
+- Automatically sets up Java development environment
+- Caches Gradle dependencies and build outputs
+- Builds APKs for Demo and Prod flavors
+- Uploads all generated APKs as artifacts
+- Provides easy access to specific APK paths
+
+## Usage Examples
+
+### Basic Usage (Debug Build)
 ```yaml
-jobs:
-  build-android-app:
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: openMF/kmp-build-android-app-action@v1.0.0
-        with:
-          android_package_name: ':app'
+- name: Build Android App
+  uses: openMF/kmp-build-android-app-action@v1.0.0
+  with:
+    android_package_name: 'myapp'
 ```
 
-## Build Process
+### Specific Build Type
+```yaml
+- name: Build Android Release
+  uses: openMF/kmp-build-android-app-action@v1.0.0
+  with:
+    android_package_name: 'myapp'
+    build_type: 'Release'
+```
 
-The action performs the following steps:
+### Accessing APK Paths
+```yaml
+- name: Build Android App
+  id: build-android
+  uses: openMF/kmp-build-android-app-action@v1.0.0
+  with:
+    android_package_name: 'myapp'
 
-1. Set up Java 17 development environment using Zulu OpenJDK
-2. Configure Gradle build system
-3. Cache Gradle dependencies and build outputs
-4. Build the specified Android module in debug mode using `./gradlew :module_name:assembleDebug`
-5. Upload generated APK as a workflow artifact
+- name: Display APK Paths
+  run: |
+    echo "Demo APK: ${{ steps.build-android.outputs.demo_apk }}"
+    echo "Prod APK: ${{ steps.build-android.outputs.prod_apk }}"
+```
 
 ## Prerequisites
 
-- Android project using Gradle as the build system
-- Gradle wrapper configured in the project
-- Clearly defined Android module name
+- Gradle project with demo and prod flavors configured
+- GitHub Actions workflow environment
 
-## Recommendations
+## Requirements
 
-- Use the fully qualified module name (e.g., `:app` for the root app module)
-- Ensure your Gradle build scripts are correctly configured
-- Verify the module name matches exactly with your project structure
+- Java 17
+- Gradle 7.x or higher
+- Android Gradle Plugin compatible with the project
+
+## Notes
+
+- The action assumes standard Android project structure
+- APK paths are dynamically discovered based on build configuration
+- All generated APKs are uploaded as artifacts for easy access
 
 ## Troubleshooting
 
-- Confirm Java 17 compatibility with your Android project
-- Check Gradle configuration and module naming
-- Review GitHub Actions logs for specific build errors
-- Verify that the specified module exists in your project
-
+- Ensure your Gradle build script correctly defines demo and prod flavors
+- Verify that APK generation paths match the action's search pattern
+- Check Gradle build logs for any build-related issues

--- a/action.yaml
+++ b/action.yaml
@@ -1,5 +1,5 @@
 name: 'KMP Build Android App'
-description: 'Build the Android application in Debug mode'
+description: 'Build the Android application using Gradle'
 author: 'Mifos Initiative'
 branding:
   icon: 'play'
@@ -9,6 +9,22 @@ inputs:
   android_package_name:
     description: 'Name of the Android project module'
     required: true
+
+  build_type:
+    description: 'Type of build to perform'
+    required: true
+    default: 'Debug'
+
+outputs:
+  demo_apk:
+    description: 'Path to Demo APK'
+    value: ${{ steps.collect-apks.outputs.demo_apk }}
+  prod_apk:
+    description: 'Path to Prod APK'
+    value: ${{ steps.collect-apks.outputs.prod_apk }}
+  artifact-name:
+    description: 'Name of the artifact'
+    value: ${{ steps.collect-apks.outputs.artifact-name }}
 
 runs:
   using: composite
@@ -35,10 +51,31 @@ runs:
 
     - name: Build Android App
       shell: bash
-      run: ./gradlew :${{ inputs.android_package_name }}:assembleDebug
+      run: ./gradlew :${{ inputs.android_package_name }}:assemble${{ inputs.build_type }}
+
+    - name: Collect APK Paths
+      id: collect-apks
+      shell: bash
+      run: |
+        # Find Demo APK
+        demo_apk=$(find . -path "**/build/outputs/apk/**/demo/**/*${{ inputs.build_type }}*.apk" -print -quit)
+
+        # Find Prod APK
+        prod_apk=$(find . -path "**/build/outputs/apk/**/prod/**/*${{ inputs.build_type }}*.apk" -print -quit)
+
+        # Output APK paths
+        echo "demo_apk=${demo_apk}" >> $GITHUB_OUTPUT
+        echo "prod_apk=${prod_apk}" >> $GITHUB_OUTPUT
+        echo "artifact-name=android-app" >> $GITHUB_OUTPUT
+
+        # Print for logging
+        echo "Demo APK: ${demo_apk}"
+        echo "Prod APK: ${prod_apk}"
 
     - name: Upload APK as artifact
       uses: actions/upload-artifact@v4
       with:
-        name: APK
-        path: '**/build/outputs/apk/**/*.apk'
+        name: ${{ steps.collect-apks.outputs.artifact-name }}
+        path: |
+          ${{ steps.collect-apks.outputs.demo_apk }}
+          ${{ steps.collect-apks.outputs.prod_apk }}


### PR DESCRIPTION
This commit enhances the GitHub Action to allow specifying the build type for Android applications.

- Adds a new input parameter `build_type` to the action, defaulting to `Debug`.
- Updates the Gradle build command to use the provided build type.
- Updates the action description to reflect the new functionality.

This change enables building Android apps in different configurations, such as `Release` or `Debug`, by simply setting the `build_type` input.