### PR TITLE
feat: Remove Base64 encoding for google-services.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ flowchart TD
 - **Type**: `string`
 
 ### `google_services` (Optional)
-- **Description**: Base64 encoded google-services.json file
+- **Description**: google-services.json file
 - **Required**: `false`
 - **Type**: `string`
 

--- a/action.yaml
+++ b/action.yaml
@@ -84,8 +84,7 @@ runs:
         echo $KEYSTORE | base64 --decode > ${{ inputs.android_package_name }}/release_keystore.keystore
 
         # Inflate google-services.json
-        echo $GOOGLE_SERVICES  | base64 --decode > ${{ inputs.android_package_name }}/google-services.json
-
+        echo $GOOGLE_SERVICES > ${{ inputs.android_package_name }}/google-services.json
 
     - name: Build Debug Android App
       if: ${{ inputs.build_type == 'Debug' }}

--- a/action.yaml
+++ b/action.yaml
@@ -77,14 +77,11 @@ runs:
         KEYSTORE: ${{ inputs.key_store }}
         GOOGLE_SERVICES: ${{ inputs.google_services }}
       run: |
-        # Mock debug google-services.json
-        cp .github/mock-google-services.json ${{ inputs.android_package_name }}/google-services.json
-
         # Inflate keystore
         echo $KEYSTORE | base64 --decode > ${{ inputs.android_package_name }}/release_keystore.keystore
 
         # Inflate google-services.json
-        echo $GOOGLE_SERVICES > ${{ inputs.android_package_name }}/google-services.json
+        echo $GOOGLE_SERVICES | base64 --decode > ${{ inputs.android_package_name }}/google-services.json
 
     - name: Build Debug Android App
       if: ${{ inputs.build_type == 'Debug' }}


### PR DESCRIPTION
This commit removes the Base64 encoding requirement for the `google_services` input.

The `google_services` input now accepts the raw `google-services.json` file content instead of its Base64 encoded version. This simplifies the workflow and makes it more user-friendly.

The action directly writes the provided `google_services` content to the `google-services.json` file without decoding it.